### PR TITLE
Add support for new value and gas syntax

### DIFF
--- a/src/ASTBuilder.js
+++ b/src/ASTBuilder.js
@@ -747,6 +747,19 @@ const transformAST = {
             index: this.visit(ctx.getChild(2))
           }
         }
+
+        // expression with nameValueList
+        if (
+          toText(ctx.getChild(1)) === '{' &&
+          toText(ctx.getChild(3)) === '}'
+        ) {
+          return {
+            type: 'NameValueExpression',
+            expression: this.visit(ctx.getChild(0)),
+            arguments: this.visit(ctx.getChild(2))
+          }
+        }
+
         break
 
       case 5:
@@ -807,6 +820,20 @@ const transformAST = {
     }
 
     throw new Error('Unrecognized expression')
+  },
+
+  NameValueList(ctx) {
+    const values = {}
+
+    for (const nameValue of ctx.nameValue()) {
+      const name = toText(nameValue.identifier())
+      values[name]  =this.visit(nameValue.expression())
+    }
+
+    return {
+      type: 'NameValueList',
+      values,
+    }
   },
 
   StateVariableDeclaration(ctx) {

--- a/test/ast.js
+++ b/test/ast.js
@@ -1829,4 +1829,67 @@ describe('AST', () => {
       "type": "AssemblyIf"
     })
   })
+
+  it("Function call with name/value list", function() {
+    let expr = parseExpression("recipient.call{value: 1}()")
+    assert.deepEqual(expr, {
+      "type": "FunctionCall",
+      "expression": {
+        "arguments": {
+          "type": "NameValueList",
+          "values": {
+            "value": {
+              "number": "1",
+              "subdenomination": null,
+              "type": "NumberLiteral"
+            }
+          }
+        },
+        "expression": {
+          "expression": {
+            "name": "recipient",
+            "type": "Identifier"
+          },
+          "memberName": "call",
+          "type": "MemberAccess"
+        },
+        "type": "NameValueExpression"
+      },
+      "arguments": [],
+      "names": []
+    })
+
+    expr = parseExpression("recipient.call{value: 1, gas: 21000}()")
+    assert.deepEqual(expr, {
+      "type": "FunctionCall",
+      "expression": {
+        "arguments": {
+          "type": "NameValueList",
+          "values": {
+            "value": {
+              "number": "1",
+              "subdenomination": null,
+              "type": "NumberLiteral"
+            },
+            "gas": {
+              "number": "21000",
+              "subdenomination": null,
+              "type": "NumberLiteral"
+            }
+          }
+        },
+        "expression": {
+          "expression": {
+            "name": "recipient",
+            "type": "Identifier"
+          },
+          "memberName": "call",
+          "type": "MemberAccess"
+        },
+        "type": "NameValueExpression"
+      },
+      "arguments": [],
+      "names": []
+    })
+  })
 })

--- a/test/test.sol
+++ b/test/test.sol
@@ -676,3 +676,11 @@ contract Inherited is Base1, Base2
     // override it
     function foo() public override(Base1, Base2) {}
 }
+
+contract CallWithNameValue {
+  function foo() {
+    recipient.call("");
+    recipient.call{value: 1}("");
+    recipient.call{value: 1, gas: 1000}("");
+  }
+}


### PR DESCRIPTION
This PR adds support for the new call syntax:

```
(bool success, ) = recipient.call{gas: 1000}("");
```

In the grammar, the relevant part is:

```
  | expression '{' nameValueList '}'
```

Which is weird because it means that any expression can be followed with a name value list (I don't think the compiler allows anything like this?). But anyway I reflected this in the parser. So a function call will have a structure like this:

```
{
  type: 'FunctionCall',
  arguments: [...] // as always,
  expression: {
    type: 'NameValueList',
    values: {
      gas: 1000
    }
  }
}
```

It's not _exactly_ like this; check the tests to see the real result. The important part to notice here is that the values are expressed as an object. This isn't consistent with, for example, how a similar thing is expressed:

```
foo({ a: 1})
```

which the parser represents with two arrays: `args: ['a']` and `values: [1]` (again, not exactly like this, but you get the idea).

---

So I'm not sure about this API in two regards: should the parser only "recognize" this syntax for function calls, and reflect that in the returned ast? Something like:

```
{
  type: 'FunctionCall',
  arguments: [...],
  expression: ...,
  iDontKnowHowToCallThis: { gas: 1000 }
}
```

And my second question is, should we represent these values as two arrays of the same length for consistency, even if it's less comfortable to work with?

@nventuro I think you don't use the parser directly, but I would love your input in the conceptual side of this.